### PR TITLE
Add Strawpoll functionality 

### DIFF
--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -6,9 +6,15 @@ import json
 import traceback
 import discord
 import asyncio
+from concurrent.futures import CancelledError
 from html import unescape
-from time import sleep, time
+from time import sleep, time, strftime
 from discord.ext import commands
+
+REFRESH_EMOJI = '🔄'
+POLL_LENGTH = 60.0
+POLL_REACT_TIME = 1800.0 #30 minutes
+BAR_LENGTH = 30
 
 def _get_poll(poll_id):
     # https://strawpoll.me/api/v2/polls/{poll_id}
@@ -21,6 +27,8 @@ def _get_poll(poll_id):
             retries=3, timeout=3.0)
         json_response = json.loads(request.data.decode('utf-8'))
     except urllib3.exceptions.HTTPError:
+        return None
+    except json.decoder.JSONDecodeError:
         return None
     return json_response
     
@@ -53,17 +61,16 @@ def _post_poll(title, options, multi):
 class _Poll:
     """Internal poll class for Strawpoll cog"""
     
-    def __init__(self, bot, message, author, poll_id, start_time, poll_length):
+    def __init__(self, bot, message, author, poll_id, poll_length):
         self.bot = bot
         self.message = message
         self.author = author
         self.poll_id = poll_id
         self.poll_length = poll_length
-        self.start_time = start_time
+        self.start_time = time()
 
     def _bar_creator(self, data, option):
         display_bar = " :: "
-        BAR_LENGTH = 30
         for y in range(BAR_LENGTH):
             if (max(data['votes']) > 0):
                 pct = float(
@@ -76,6 +83,9 @@ class _Poll:
 
     async def update_results(self):
         data = _get_poll(self.poll_id)
+        if data is None:
+            await self.bot.edit_message(self.message, 
+                embed=discord.Embed(title="Error receiving strawpoll data!"))
         embed=discord.Embed(title=unescape(data['title']), 
             url='https://strawpoll.me/' + str(self.poll_id), 
             description="Strawpoll Results", color=self.author.color)
@@ -94,30 +104,68 @@ class _Poll:
             embed.set_footer(text="{} sec{} left".format(
                 str(time_left), '' if (time_left == 1) else 's'))
         else: 
-            embed.set_footer(text="poll completed!")   
+            embed.set_footer(text="as of {}".format(
+                strftime('%A %B %-m, %Y // %I:%M:%S%p ').lower()))
         await self.bot.edit_message(self.message, embed=embed)
 
 class Strawpoll:
     """Create, link, and update live results for a Strawpoll within Discord"""
-
+    
     def __init__(self, bot):
         self.bot = bot
         self.poll_sessions = []
+        self.poll_session_tasks = {}
 
     async def _say_usage(self):
         await self.bot.say(
         "strawpoll question;option1;option2 (...)\n"
         "strawpoll m question;option1;option2 (...)")
+
+    async def check_polls(self):
+        while self is self.bot.get_cog("Strawpoll"):
+            current_time = time()
+            for poll in self.poll_sessions:
+                if poll not in self.poll_session_tasks:
+                    self.poll_session_tasks[poll] = asyncio.ensure_future(
+                        self._check_reacts(poll))
+            for poll in self.poll_session_tasks.keys():
+                if current_time-poll.start_time > POLL_REACT_TIME:
+                    self.poll_session_tasks[poll].cancel()
+            self.poll_sessions[:] = [
+                poll for poll in self.poll_sessions 
+                if current_time-poll.start_time < POLL_REACT_TIME]
+            self.poll_session_tasks = { 
+                poll:task for poll,task in self.poll_session_tasks.items() 
+                if not task.done()}
+            await asyncio.sleep(5)
+        for poll in self.poll_session_tasks.keys():
+            self.poll_session_tasks[poll].cancel()
         
-    async def _create_poll(self, message, author, poll_id):
-        POLL_LENGTH = 60.0
-        start_time = time()
+    async def _check_reacts(self, poll):
+        try:
+            while True:
+                react = await self.bot.wait_for_reaction(REFRESH_EMOJI, 
+                    message=poll.message)
+                await poll.update_results()
+                await asyncio.sleep(0.5) # don't remove reaction too fast
+                await self.bot.remove_reaction(
+                    poll.message, REFRESH_EMOJI, react.user)
+        except CancelledError:
+            await self.bot.clear_reactions(poll.message)
+            raise CancelledError("Poll cancelled")
+            
+    async def _create_poll(self, message, channel, author, poll_id):
         poll = _Poll(self.bot, message, author, 
-            poll_id, start_time, POLL_LENGTH)
-        while time()-start_time < POLL_LENGTH:
+            poll_id, POLL_LENGTH)
+        while time()-poll.start_time < POLL_LENGTH:
             await poll.update_results()
-            sleep(1)
+            await asyncio.sleep(1)
+        await self.bot.delete_message(poll.message)
+        poll.message = await self.bot.send_message(channel,
+            embed=discord.Embed(title="Loading results..."))
         await poll.update_results()
+        await self.bot.add_reaction(poll.message, REFRESH_EMOJI)
+        self.poll_sessions.append(poll)
             
     @commands.command(pass_context=True)
     async def strawpoll(self, ctx, *text):
@@ -155,10 +203,14 @@ class Strawpoll:
         results_message = await self.bot.send_message(
             ctx.message.channel, 
             embed=discord.Embed(title="Loading strawpoll..."))
-        asyncio.ensure_future(
-            self._create_poll(
-                results_message, ctx.message.author, response['id']))
+        await self._create_poll(
+            results_message, ctx.message.channel, 
+            ctx.message.author, response['id'])
 
 def setup(bot):
-    bot.add_cog(Strawpoll(bot))
+    cog = Strawpoll(bot)
+    loop = asyncio.get_event_loop()
+    loop.create_task(cog.check_polls())
+    bot.add_cog(cog)
+
     

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -1,5 +1,9 @@
 # Strawpoll functionality by Savestate for Red-DiscordBot
 
+import urllib3
+import certifi
+import json
+import traceback
 import discord
 from discord.ext import commands
 
@@ -11,17 +15,34 @@ class Strawpoll:
         
     @commands.command(pass_context=True)
     async def strawpoll(self, ctx):
-        """Create and link a new Strawpoll froom user input"""
-        test_embed = discord.Embed(
-            title = "strawpoll embed title", type = "rich", 
-            description = "strawpoll embed description", 
-            url = "http://example.net", 
-            colour = discord.Colour(0x206010))
-        # add_field(*, name, value, inline=True)
-        test_embed.add_field(name="test_inline_true", value="test_value", inline=True)
-        test_embed.add_field(name="test_inline_false", value="test_value2", inline=False)
-        test_embed.set_image(url="https://pbs.twimg.com/media/DQZI3ApV4AAitZc.jpg") #thanks mushbuh
-        await self.bot.send_message(ctx.message.channel, content=None, embed=test_embed)
-        
+        https = urllib3.PoolManager(
+            cert_reqs='CERT_REQUIRED',
+            ca_certs=certifi.where())
+        data = {
+            'title': 'test poll title',
+            'options': [
+                'option 1',
+                'option 2', 
+                'option 3',
+                'option 4???'],
+            'multi': True,
+            'dupcheck': 'normal',
+            'captcha': False }
+        encoded_data = json.dumps(data).encode('utf-8')
+        try:
+            request = https.request(
+                'POST', 'https://strawpoll.me/api/v2/polls',
+                body=encoded_data, headers={
+                    'Content-Type': 'application/json',
+                    'Accept-Charset': 'utf-8'
+                },
+                retries=3, timeout=3.0)
+            json_response = json.loads(request.data.decode('utf-8'))
+        except urllib3.exceptions.RequestError as e:
+            await self.bot.send_message(ctx.message.channel, "oooooops lmao")
+            return
+        await self.bot.send_message(ctx.message.channel,
+            ''.join(['http://www.strawpoll.me/', str(json_response['id'])]))
+
 def setup(bot):
     bot.add_cog(Strawpoll(bot))

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -143,7 +143,6 @@ class Strawpoll:
     def _new_server_settings(self, server_id):
         default_settings = {
             'refresh_emoji': '🔄',
-            'poll_length': 30.0,
             'poll_react_time': 300.0, # 5 minutes
             'bar_length': 30
         }
@@ -423,7 +422,6 @@ class Strawpoll:
     
         Settings:
             refresh_emoji    Manual refresh emoji once a poll ends
-            poll_length      Time in seconds for the default length of a poll
             poll_react_time  How long in seconds the refresh emoji stays active
             bar_length       How long the distribution bars in the embed are
         """

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -335,6 +335,17 @@ class Strawpoll:
     @commands.command(name="strawpollset", pass_context=True)
     @checks.mod_or_permissions(manage_server=True)
     async def strawpoll_settings(self, ctx, *text):
+        """
+        Adjust strawpoll default settings
+    
+        Usage: strawpollset option value
+        
+        Options:
+            refresh_emoji    Manual refresh emoji once a poll ends
+            poll_length      Time in seconds for the default length of a poll
+            poll_react_time  How long in seconds the refresh emoji stays active
+            bar_length       How long the distribution bars in the embed are
+        """
         server_id = ctx.message.server.id
         if server_id not in self.settings:
             self._new_server_settings(server_id)

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -139,11 +139,6 @@ class Strawpoll:
         self.settings[server_id] = default_settings
         dataIO.save_json(self.settings_path, self.settings)
 
-    async def _say_usage(self):
-        await self.bot.say(
-        "```strawpoll question;option1;option2 (...)\n"
-        "strawpoll m question;option1;option2 (...)```")
-
     def _check_new_poll_tasks(self):
         for poll in self.poll_sessions:
             if poll not in self.poll_session_tasks:
@@ -215,18 +210,26 @@ class Strawpoll:
     
     @commands.command(pass_context=True, no_pm=True)
     async def strawpoll(self, ctx, *text):
+        """
+        Host a poll on Strawpoll.me with live results
+
+        Usage: strawpoll [m] title;option 1;option 2 (...)
+        
+        Options:
+            m       Allow multiple options to be selected
+        """
         if ctx.message.server.id not in self.settings:
             self._new_server_settings(ctx.message.server.id)
         multi = False
         if len(text) <= 0:
-            await self._say_usage()
+            await self.bot.send_cmd_help(ctx)
             return
         if text[0] is 'm':
             multi = True
             text = text[1:]
         poll = ' '.join(text).split(';', 1)
         if len(poll) != 2:
-            await self._say_usage()
+            await self.bot.send_cmd_help(ctx)
             return
         options = poll[1].split(';')
         # ~ fancy way of removing empty strings ~
@@ -244,7 +247,7 @@ class Strawpoll:
             await self.bot.say(
                 "Strawpoll error: `{}`"
                 .format(response['errorMessage']))
-            await self._say_usage()
+            await self.bot.send_cmd_help(ctx)
             return
         results_message = await self.bot.send_message(
             ctx.message.channel, 

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -75,7 +75,7 @@ class _Poll:
     # https://www.w3resource.com/python-exercises/python-basic-exercise-65.php
     def _time_left(self, seconds):
         days = seconds // (24 * 3600)
-        seconds = seconds % (24 * 3600)
+        seconds %= (24 * 3600)
         hours = seconds // 3600
         seconds %= 3600
         minutes = seconds // 60
@@ -354,8 +354,14 @@ class Strawpoll:
     @strawpoll.command(pass_context=True, no_pm=True)
     async def stop(self, ctx, *search_terms):
         """
-        Stop a poll on Strawpoll.me that matches search terms
+        Stop a currently running poll that matches search terms
+        
+        Options:
+            search_terms Search terms matching a currently running poll
         """
+        if not search_terms:
+            await self.bot.send_cmd_help(ctx)
+            return
         await self._stop_poll(' '.join(search_terms),
             ctx.message.channel, ctx.message.author)
 

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -12,23 +12,21 @@ class Strawpoll:
 
     def __init__(self, bot):
         self.bot = bot
+        self.poll_sessions = []
         
-    @commands.command(pass_context=True)
-    async def strawpoll(self, ctx):
-        https = urllib3.PoolManager(
-            cert_reqs='CERT_REQUIRED',
-            ca_certs=certifi.where())
+    def _post_poll(self, title, options, multi):
+        # build json request
         data = {
-            'title': 'test poll title',
-            'options': [
-                'option 1',
-                'option 2', 
-                'option 3',
-                'option 4???'],
-            'multi': True,
+            'title': title,
+            'options': options,
+            'multi': multi,
             'dupcheck': 'normal',
             'captcha': False }
         encoded_data = json.dumps(data).encode('utf-8')
+        # urllib3 pool manager in https mode
+        https = urllib3.PoolManager(
+            cert_reqs='CERT_REQUIRED',
+            ca_certs=certifi.where())
         try:
             request = https.request(
                 'POST', 'https://strawpoll.me/api/v2/polls',
@@ -38,11 +36,44 @@ class Strawpoll:
                 },
                 retries=3, timeout=3.0)
             json_response = json.loads(request.data.decode('utf-8'))
-        except urllib3.exceptions.RequestError as e:
-            await self.bot.send_message(ctx.message.channel, "oooooops lmao")
+        except urllib3.exceptions.HTTPError:
+            return None
+        return json_response
+            
+    @commands.command(pass_context=True)
+    async def strawpoll(self, ctx, *text):
+        multi = False
+        if text[0] is 'm':
+            multi = True
+            text = text[1:]
+        poll = ' '.join(text).split(';', 1)
+        if len(poll) != 2:
+            await self.bot.say(
+                "strawpoll question;option1;option2 (...)\n"
+                "strawpoll m question;option1;option2 (...)")
             return
-        await self.bot.send_message(ctx.message.channel,
-            ''.join(['http://www.strawpoll.me/', str(json_response['id'])]))
+        options = poll[1].split(';')
+        for i in range(len(options)):
+            options[i] = options[i].strip()
+        # ~ fancy way of removing empty strings ~
+        # if a string is empty, it evaluates to false.
+        # so, if an option from options has content, then
+        # assign that option for itself, otherwise it wont get
+        # included in the splice. (took me a sec to parse it lol)
+        options[:] = [option for option in options if option]
+        response = self._post_poll(poll[0], options, multi)
+        if not response:
+            await self.bot.say("Uh-oh, no response from Strawpoll received!")
+            return
+        if 'errorMessage' in response:
+            await self.bot.say(
+                "Strawpoll error: `{}`\n\n"
+                "usage: \n"
+                "strawpoll question;option1;option2 (...)\n"
+                "strawpoll m question;option1;option2 (...)"
+                .format(response['errorMessage']))
+            return
+        await self.bot.say('```{}```'.format(response))
 
 def setup(bot):
     bot.add_cog(Strawpoll(bot))

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -5,6 +5,8 @@ import certifi
 import json
 import traceback
 import discord
+import asyncio
+from time import sleep
 from discord.ext import commands
 
 class Strawpoll:
@@ -13,6 +15,58 @@ class Strawpoll:
     def __init__(self, bot):
         self.bot = bot
         self.poll_sessions = []
+        
+    async def _say_usage(self):
+        await self.bot.say(
+        "strawpoll question;option1;option2 (...)\n"
+        "strawpoll m question;option1;option2 (...)")
+        
+    async def _update_results(self, message, author, poll_id, countdown):
+        for x in range(countdown):
+            data = self._get_poll(poll_id)
+            embed=discord.Embed(title=data['title'], 
+                url='http://strawpoll.me/' + str(poll_id), 
+                description="Strawpoll Results", color=author.color)
+            embed.set_author(name=author.nick, icon_url=author.avatar_url)
+            for option in range(len(data['options'])):
+                BAR_LENGTH = 30
+                display_bar = ''
+                for y in range(BAR_LENGTH):
+                    if (max(data['votes']) > 0):
+                        pct = float(data['votes'][option])/float(max(data['votes']))
+                    else:
+                        pct = 0.0
+                    if (pct == 0.0):
+                        continue
+                    display_bar += '|' if (pct >= float(y)/float(BAR_LENGTH-1)) else ''
+                embed.add_field(inline=False, 
+                    name="{} ({} Vote{})".format(
+                        data['options'][option],
+                        str(data['votes'][option]),
+                        '' if (data['votes'][option] == 1) else 's'),
+                    value=" :: {}".format(display_bar))
+            time_left = countdown-x-1
+            if (time_left > 0):
+                embed.set_footer(text="{} sec{} left".format(
+                    str(time_left), '' if (time_left == 1) else 's'))
+            else: 
+                embed.set_footer(text="poll completed!")                
+            await self.bot.edit_message(message, embed=embed)
+            sleep(1)
+        
+    def _get_poll(self, poll_id):
+        # https://strawpoll.me/api/v2/polls/{poll_id}
+        https = urllib3.PoolManager(
+            cert_reqs='CERT_REQUIRED',
+            ca_certs=certifi.where())
+        try:
+            request = https.request( 'GET', 
+                'https://strawpoll.me/api/v2/polls/' + str(poll_id),
+                retries=3, timeout=3.0)
+            json_response = json.loads(request.data.decode('utf-8'))
+        except urllib3.exceptions.HTTPError:
+            return None
+        return json_response
         
     def _post_poll(self, title, options, multi):
         # build json request
@@ -43,14 +97,15 @@ class Strawpoll:
     @commands.command(pass_context=True)
     async def strawpoll(self, ctx, *text):
         multi = False
+        if len(text) <= 0:
+            await self._say_usage()
+            return
         if text[0] is 'm':
             multi = True
             text = text[1:]
         poll = ' '.join(text).split(';', 1)
         if len(poll) != 2:
-            await self.bot.say(
-                "strawpoll question;option1;option2 (...)\n"
-                "strawpoll m question;option1;option2 (...)")
+            await self._say_usage()
             return
         options = poll[1].split(';')
         for i in range(len(options)):
@@ -63,17 +118,20 @@ class Strawpoll:
         options[:] = [option for option in options if option]
         response = self._post_poll(poll[0], options, multi)
         if not response:
-            await self.bot.say("Uh-oh, no response from Strawpoll received!")
+            await self.bot.send_message(ctx.message.channel, 
+                "Uh-oh, no response from Strawpoll received!")
             return
         if 'errorMessage' in response:
             await self.bot.say(
-                "Strawpoll error: `{}`\n\n"
-                "usage: \n"
-                "strawpoll question;option1;option2 (...)\n"
-                "strawpoll m question;option1;option2 (...)"
+                "Strawpoll error: `{}`"
                 .format(response['errorMessage']))
+            await self._say_usage()
             return
-        await self.bot.say('```{}```'.format(response))
+        results_message = await self.bot.send_message(
+            ctx.message.channel, 'Loading strawpoll data...')
+        asyncio.ensure_future(
+            self._update_results(
+                results_message, ctx.message.author, response['id'], 60))
 
 def setup(bot):
     bot.add_cog(Strawpoll(bot))

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -1,0 +1,27 @@
+# Strawpoll functionality by Savestate for Red-DiscordBot
+
+import discord
+from discord.ext import commands
+
+class Strawpoll:
+    """Create, link, and update live results for a Strawpoll within Discord"""
+
+    def __init__(self, bot):
+        self.bot = bot
+        
+    @commands.command(pass_context=True)
+    async def strawpoll(self, ctx):
+        """Create and link a new Strawpoll froom user input"""
+        test_embed = discord.Embed(
+            title = "strawpoll embed title", type = "rich", 
+            description = "strawpoll embed description", 
+            url = "http://example.net", 
+            colour = discord.Colour(0x206010))
+        # add_field(*, name, value, inline=True)
+        test_embed.add_field(name="test_inline_true", value="test_value", inline=True)
+        test_embed.add_field(name="test_inline_false", value="test_value2", inline=False)
+        test_embed.set_image(url="https://pbs.twimg.com/media/DQZI3ApV4AAitZc.jpg") #thanks mushbuh
+        await self.bot.send_message(ctx.message.channel, content=None, embed=test_embed)
+        
+def setup(bot):
+    bot.add_cog(Strawpoll(bot))

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -300,17 +300,27 @@ class Strawpoll:
             str(poll._time_left(poll.poll_length)) + "`")
         return
 
-    async def _poll_args_process(self, ctx, hours, text, multi):
+    async def _poll_args_process(self, ctx, time, time_unit, text, multi):
         if ctx.message.server.id not in self.settings:
             self._new_server_settings(ctx.message.server.id)
         if len(text) <= 0:
             await self.bot.send_cmd_help(ctx)
             return
-        try:
-            poll_length = hours * 60 * 60 # hours to seconds
-        except ValueError:
-            settings = self.settings[ctx.message.server.id]
-            poll_length = settings['poll_length']
+        time_unit = time_unit.lower()
+        if time_unit.startswith('second'):
+            poll_length = time # seconds
+        elif time_unit.startswith('minute'):
+            poll_length = time * 60 # minutes to seconds
+        elif time_unit.startswith('hour'):
+            poll_length = time * 60 * 60 # hours to seconds
+        elif time_unit.startswith('day'):
+            poll_length = time * 60 * 60 * 24 # days to seconds
+        else:
+            await self.bot.say(
+                "Unknown time unit! Accepted units are:" + 
+                "`second(s)`, `minute(s)`, `hour(s)`, `day(s)`.")
+            await self.bot.send_cmd_help(ctx)
+            return
         poll = ' '.join(text).split(';', 1)
         if len(poll) != 2:
             await self.bot.send_cmd_help(ctx)
@@ -351,29 +361,31 @@ class Strawpoll:
             ctx.message.channel, ctx.message.author)
 
     @strawpoll.command(pass_context=True, no_pm=True)
-    async def multi(self, ctx, hours:float, *text):
+    async def multi(self, ctx, time:float, time_unit:str, *text):
         """
         Host a multiple choice poll on Strawpoll.me with live results
 
         Options:
-            hours   How many hours to run the poll 
-                    (can be a decimal. eg. 0.1)
-            text    title;option 1;option 2;option 3(...)
+            time       How many `time_units` to run the poll 
+                       (can be a decimal. eg. 0.1)
+            time_unit  'seconds', 'minutes', 'hours', 'days'
+            text       title;option 1;option 2;option 3(...)
         """
-        await self._poll_args_process(ctx, hours, text, True)
+        await self._poll_args_process(ctx, time, time_unit, text,  True)
 
 
     @strawpoll.command(pass_context=True, no_pm=True)
-    async def host(self, ctx, hours:float, *text):
+    async def host(self, ctx, time:float, time_unit:str, *text):
         """
         Host a poll on Strawpoll.me with live results
 
         Options:
-            hours   How many hours to run the poll 
-                    (can be a decimal. eg. 0.1)
-            text    title;option 1;option 2;option 3(...)
+            time       How many `time_units` to run the poll 
+                       (can be a decimal. eg. 0.1)
+            time_unit  'seconds', 'minutes', 'hours', 'days'
+            text       title;option 1;option 2;option 3(...)
         """
-        await self._poll_args_process(ctx, hours, text, False)
+        await self._poll_args_process(ctx, time, time_unit, text, False)
 
     @strawpoll.command(pass_context=True, no_pm=True)
     async def extend(self, ctx, hours:float, *search_terms):

--- a/cogs/strawpoll.py
+++ b/cogs/strawpoll.py
@@ -6,8 +6,96 @@ import json
 import traceback
 import discord
 import asyncio
-from time import sleep
+from html import unescape
+from time import sleep, time
 from discord.ext import commands
+
+def _get_poll(poll_id):
+    # https://strawpoll.me/api/v2/polls/{poll_id}
+    https = urllib3.PoolManager(
+        cert_reqs='CERT_REQUIRED',
+        ca_certs=certifi.where())
+    try:
+        request = https.request( 'GET', 
+            'https://strawpoll.me/api/v2/polls/' + str(poll_id),
+            retries=3, timeout=3.0)
+        json_response = json.loads(request.data.decode('utf-8'))
+    except urllib3.exceptions.HTTPError:
+        return None
+    return json_response
+    
+def _post_poll(title, options, multi):
+    # build json request
+    data = {
+        'title': title,
+        'options': options,
+        'multi': multi,
+        'dupcheck': 'normal',
+        'captcha': False }
+    encoded_data = json.dumps(data).encode('utf-8')
+    # urllib3 pool manager in https mode
+    https = urllib3.PoolManager(
+        cert_reqs='CERT_REQUIRED',
+        ca_certs=certifi.where())
+    try:
+        request = https.request(
+            'POST', 'https://strawpoll.me/api/v2/polls',
+            body=encoded_data, headers={
+                'Content-Type': 'application/json',
+                'Accept-Charset': 'utf-8'
+            },
+            retries=3, timeout=3.0)
+        json_response = json.loads(request.data.decode('utf-8'))
+    except urllib3.exceptions.HTTPError:
+        return None
+    return json_response
+
+class _Poll:
+    """Internal poll class for Strawpoll cog"""
+    
+    def __init__(self, bot, message, author, poll_id, start_time, poll_length):
+        self.bot = bot
+        self.message = message
+        self.author = author
+        self.poll_id = poll_id
+        self.poll_length = poll_length
+        self.start_time = start_time
+
+    def _bar_creator(self, data, option):
+        display_bar = " :: "
+        BAR_LENGTH = 30
+        for y in range(BAR_LENGTH):
+            if (max(data['votes']) > 0):
+                pct = float(
+                    data['votes'][option])/float(max(data['votes']))
+            else:
+                continue
+            if (pct != 0 and pct >= float(y)/float(BAR_LENGTH-1)):
+                display_bar += '|'
+        return display_bar
+
+    async def update_results(self):
+        data = _get_poll(self.poll_id)
+        embed=discord.Embed(title=unescape(data['title']), 
+            url='https://strawpoll.me/' + str(self.poll_id), 
+            description="Strawpoll Results", color=self.author.color)
+        embed.set_author(
+            name=self.author.nick if self.author.nick else self.author.name, 
+            icon_url=self.author.avatar_url)
+        for option in range(len(data['options'])):
+            embed.add_field(inline=False, 
+                name="{} ({} Vote{})".format(
+                    unescape(data['options'][option]),
+                    str(data['votes'][option]),
+                    '' if (data['votes'][option] == 1) else 's'),
+                value=self._bar_creator(data, option))
+        time_left = round(self.poll_length-(time()-self.start_time))
+        if (time_left > 0):
+            embed.set_footer(text="{} sec{} left".format(
+                str(time_left), '' if (time_left == 1) else 's'))
+        else: 
+            embed.set_footer(text="poll completed!")   
+        await self.bot.edit_message(self.message, embed=embed)
 
 class Strawpoll:
     """Create, link, and update live results for a Strawpoll within Discord"""
@@ -15,84 +103,21 @@ class Strawpoll:
     def __init__(self, bot):
         self.bot = bot
         self.poll_sessions = []
-        
+
     async def _say_usage(self):
         await self.bot.say(
         "strawpoll question;option1;option2 (...)\n"
         "strawpoll m question;option1;option2 (...)")
         
-    async def _update_results(self, message, author, poll_id, countdown):
-        for x in range(countdown):
-            data = self._get_poll(poll_id)
-            embed=discord.Embed(title=data['title'], 
-                url='http://strawpoll.me/' + str(poll_id), 
-                description="Strawpoll Results", color=author.color)
-            embed.set_author(name=author.nick, icon_url=author.avatar_url)
-            for option in range(len(data['options'])):
-                BAR_LENGTH = 30
-                display_bar = ''
-                for y in range(BAR_LENGTH):
-                    if (max(data['votes']) > 0):
-                        pct = float(data['votes'][option])/float(max(data['votes']))
-                    else:
-                        pct = 0.0
-                    if (pct == 0.0):
-                        continue
-                    display_bar += '|' if (pct >= float(y)/float(BAR_LENGTH-1)) else ''
-                embed.add_field(inline=False, 
-                    name="{} ({} Vote{})".format(
-                        data['options'][option],
-                        str(data['votes'][option]),
-                        '' if (data['votes'][option] == 1) else 's'),
-                    value=" :: {}".format(display_bar))
-            time_left = countdown-x-1
-            if (time_left > 0):
-                embed.set_footer(text="{} sec{} left".format(
-                    str(time_left), '' if (time_left == 1) else 's'))
-            else: 
-                embed.set_footer(text="poll completed!")                
-            await self.bot.edit_message(message, embed=embed)
+    async def _create_poll(self, message, author, poll_id):
+        POLL_LENGTH = 60.0
+        start_time = time()
+        poll = _Poll(self.bot, message, author, 
+            poll_id, start_time, POLL_LENGTH)
+        while time()-start_time < POLL_LENGTH:
+            await poll.update_results()
             sleep(1)
-        
-    def _get_poll(self, poll_id):
-        # https://strawpoll.me/api/v2/polls/{poll_id}
-        https = urllib3.PoolManager(
-            cert_reqs='CERT_REQUIRED',
-            ca_certs=certifi.where())
-        try:
-            request = https.request( 'GET', 
-                'https://strawpoll.me/api/v2/polls/' + str(poll_id),
-                retries=3, timeout=3.0)
-            json_response = json.loads(request.data.decode('utf-8'))
-        except urllib3.exceptions.HTTPError:
-            return None
-        return json_response
-        
-    def _post_poll(self, title, options, multi):
-        # build json request
-        data = {
-            'title': title,
-            'options': options,
-            'multi': multi,
-            'dupcheck': 'normal',
-            'captcha': False }
-        encoded_data = json.dumps(data).encode('utf-8')
-        # urllib3 pool manager in https mode
-        https = urllib3.PoolManager(
-            cert_reqs='CERT_REQUIRED',
-            ca_certs=certifi.where())
-        try:
-            request = https.request(
-                'POST', 'https://strawpoll.me/api/v2/polls',
-                body=encoded_data, headers={
-                    'Content-Type': 'application/json',
-                    'Accept-Charset': 'utf-8'
-                },
-                retries=3, timeout=3.0)
-            json_response = json.loads(request.data.decode('utf-8'))
-        except urllib3.exceptions.HTTPError:
-            return None
-        return json_response
+        await poll.update_results()
             
     @commands.command(pass_context=True)
     async def strawpoll(self, ctx, *text):
@@ -116,7 +141,7 @@ class Strawpoll:
         # assign that option for itself, otherwise it wont get
         # included in the splice. (took me a sec to parse it lol)
         options[:] = [option for option in options if option]
-        response = self._post_poll(poll[0], options, multi)
+        response = _post_poll(poll[0], options, multi)
         if not response:
             await self.bot.send_message(ctx.message.channel, 
                 "Uh-oh, no response from Strawpoll received!")
@@ -128,10 +153,12 @@ class Strawpoll:
             await self._say_usage()
             return
         results_message = await self.bot.send_message(
-            ctx.message.channel, 'Loading strawpoll data...')
+            ctx.message.channel, 
+            embed=discord.Embed(title="Loading strawpoll..."))
         asyncio.ensure_future(
-            self._update_results(
-                results_message, ctx.message.author, response['id'], 60))
+            self._create_poll(
+                results_message, ctx.message.author, response['id']))
 
 def setup(bot):
     bot.add_cog(Strawpoll(bot))
+    


### PR DESCRIPTION
# strawpoll.py
## description
host a poll on [strawpoll](https://strawpoll.me/) with real-time results embedded in a discord message 

## usage
```
[p]strawpoll

Commands:
  config Display current strawpoll settings for this server
  extend Extend a currently running poll that matches search terms
  host   Host a poll on Strawpoll.me with live results
  multi  Host a multiple choice poll on Strawpoll.me with live results
  set    Adjust strawpoll default settings
  stop   Stop a poll on Strawpoll.me that matches search terms
```
## user commands
### `host`
hosts a poll on [strawpoll](https://strawpoll.me/) with real-time results embedded in a discord message 
```
[p]strawpoll host <time> <time_unit> [text...]

Options:
    time       How many time_units to run the poll 
               (can be a decimal. eg. 0.1)
    time_unit  'seconds', 'minutes', 'hours', 'days'
    text       title;option 1;option 2;option 3(...)
```
### `multi`
hosts a multiple choice poll on [strawpoll](https://strawpoll.me/) with real-time results embedded in a discord message 
```
[p]strawpoll multi <time> <time_unit> [text...]

Options:
    time       How many time_units to run the poll 
               (can be a decimal. eg. 0.1)
    time_unit  'seconds', 'minutes', 'hours', 'days'
    text       title;option 1;option 2;option 3(...)```
```
### `extend`
extend a currently running poll that matches search terms
```
[p]strawpoll extend <time> <time_unit> [search_terms...]

Options:
    time         How many time_unit to extend the poll 
                 (can be a decimal. eg. 0.1)
                 (can also be negative)
    time_unit    'seconds', 'minutes', 'hours', 'days'
    search_terms Search terms matching a currently running poll
```
### `stop`
stop a currently running poll that matches search terms
```
[p]strawpoll stop [search_terms...]

Options:
    search_terms Search terms matching a currently running poll
```
## admin commands
### `set`
discord users with server managing permissions can change the per-server settings with `[p]strawpoll set`
available options to configure are…
* `refresh_emoji` the emoji used to manually refresh the poll results after the poll ends
* `poll_react_time` time in seconds representing how long the refresh emoji stays active 
* `bar_length` how many `|` to use for the embedded vote distribution bars
```
[p]strawpoll set refresh_emoji 🌀
[p]strawpoll set poll_react_time 300
```
### `config`
discord users with server managing permissions can view the current settings load-out by invoking `[p]strawpoll config`